### PR TITLE
fix icons dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@uiw/react-md-editor": "^4.0.0"
   },
   "devDependencies": {
-    "@strapi/icons": "2.0.0-rc.11",
+    "@strapi/icons": "^2.0.0-rc.11",
     "@strapi/sdk-plugin": "^5.2.6",
     "@strapi/strapi": "^5.0.2",
     "@strapi/typescript-utils": "^5.0.2",
@@ -102,7 +102,7 @@
     "typescript": "^5.6.0"
   },
   "peerDependencies": {
-    "@strapi/icons": "2.0.0-rc.11",
+    "@strapi/icons": "^2.0.0-rc.11",
     "@strapi/sdk-plugin": "^5.2.6",
     "@strapi/strapi": "^5.0.2",
     "@strapi/typescript-utils": "^5.0.2",


### PR DESCRIPTION
Fixes the npm error on install as Strapi is now using rc14 for the icons.